### PR TITLE
Feat: #7 add CoverageMeasurement class no manually implement branch coverage measurement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ classes
 # Used to check reproducibility of Mockito jars
 checksums/
 /.tool-versions
+
+# Coverage reports
+*.cov

--- a/aggregate.py
+++ b/aggregate.py
@@ -1,0 +1,38 @@
+from glob import glob
+from collections import defaultdict
+import sys
+import shutil
+
+
+def main():
+    if "clean" in sys.argv:
+        for filename in glob("**/coverage", recursive=True):
+            shutil.rmtree(filename)
+        print("Cleaned")
+        return
+
+    coverage = defaultdict(set)
+    nb_lines = {}
+
+    for filename in glob("**/*.cov", recursive=True):
+        with open(filename, "r") as f:
+            lines = f.readlines()
+            method = lines[0][:-1]
+            nb_lines[method] = int(lines[1])
+            covered = set(int(el) for el in lines[2].split() if el)
+            coverage[lines[0][:-1]] |= covered
+
+    for method in coverage.keys():
+        not_covered = set(range(nb_lines[method])) - coverage[method]
+        print(f">>=========={method}============<<")
+        # print("Coverage data for method", method)
+        print(
+            f"Branches covered : {len(coverage[method])}/{nb_lines[method]} ({len(coverage[method]) / nb_lines[method] * 100}%)"
+        )
+        if not_covered:
+            print(f"Branches not covered : {not_covered}")
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/mockito-core/src/main/java/org/mockito/CoverageMeasurement.java
+++ b/mockito-core/src/main/java/org/mockito/CoverageMeasurement.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2025 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class CoverageMeasurement {
+
+    private static Lock lock = new ReentrantLock();
+    private static final int testId;
+    private static Map<String, MethodCoverage> coverageData = new HashMap<String, MethodCoverage>();
+    private static Map<String, Lock> locks = new HashMap<>();
+
+    static {
+        Random rand = new Random();
+        testId = rand.nextInt(Integer.MAX_VALUE);
+    }
+
+    private final String methodName;
+
+    public CoverageMeasurement(String methodName, int nbBranches) {
+        this.methodName = methodName;
+
+        lock.lock();
+        locks.putIfAbsent(methodName, new ReentrantLock());
+        lock.unlock();
+
+        locks.get(methodName).lock();
+        coverageData.putIfAbsent(methodName, new MethodCoverage(nbBranches));
+        if (coverageData.get(methodName).getNbBranches() != nbBranches) {
+            locks.get(methodName).unlock();
+            throw new RuntimeException(
+                    "Method "
+                            + methodName
+                            + " already registered with a different number of branches");
+        }
+        saveMethodCoverageState();
+        locks.get(methodName).unlock();
+    }
+
+    public void branch(int branchId) {
+        locks.get(methodName).lock();
+        MethodCoverage coverage = coverageData.get(methodName);
+        if (!coverage.isCovered(branchId)) {
+            // If coverage has changed, save it to a file
+            coverage.setCovered(branchId);
+            saveMethodCoverageState();
+        }
+        locks.get(methodName).unlock();
+    }
+
+    private void saveMethodCoverageState() {
+        MethodCoverage coverage = coverageData.get(methodName);
+        StringBuilder sb = new StringBuilder();
+        sb.append(methodName).append("\n");
+        sb.append(coverage.getNbBranches()).append("\n");
+        for (int covered : coverage.getCoveredBranches()) {
+            sb.append(covered).append(" ");
+        }
+        try {
+            Files.createDirectories(Path.of("coverage"));
+            Files.writeString(Path.of("coverage/" + testId + methodName + ".cov"), sb.toString());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}
+
+class MethodCoverage {
+    private boolean[] covered;
+
+    public MethodCoverage(int branches) {
+        covered = new boolean[branches];
+    }
+
+    public void setCovered(int branchId) {
+        this.covered[branchId] = true;
+    }
+
+    public int getNbBranches() {
+        return covered.length;
+    }
+
+    public boolean isCovered(int branchId) {
+        return covered[branchId];
+    }
+
+    public List<Integer> getCoveredBranches() {
+        List<Integer> branches = new ArrayList<Integer>();
+        for (int i = 0; i < getNbBranches(); i++) {
+            if (covered[i]) {
+                branches.add(i);
+            }
+        }
+        return branches;
+    }
+}

--- a/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMaker.java
+++ b/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/InlineDelegateByteBuddyMockMaker.java
@@ -4,6 +4,7 @@
  */
 package org.mockito.internal.creation.bytebuddy;
 
+import org.mockito.CoverageMeasurement;
 import org.mockito.MockedConstruction;
 import org.mockito.creation.instance.InstantiationException;
 import org.mockito.creation.instance.Instantiator;
@@ -215,18 +216,26 @@ class InlineDelegateByteBuddyMockMaker
     private final ThreadLocal<Object> currentSpied = new ThreadLocal<>();
 
     InlineDelegateByteBuddyMockMaker() {
+        CoverageMeasurement measurement =
+                new CoverageMeasurement(
+                        "InlineDelegateByteBuddyMockMaker::InlineDelegateByteBuddyMockMaker", 22);
+
         if (INITIALIZATION_ERROR != null) {
+            measurement.branch(1);
             String detail;
             if (PlatformUtils.isAndroidPlatform() || PlatformUtils.isProbablyTermuxEnvironment()) {
+                measurement.branch(2);
                 detail =
                         "It appears as if you are trying to run this mock maker on Android which does not support the instrumentation API.";
             } else {
+                measurement.branch(3);
                 try {
                     if (INITIALIZATION_ERROR instanceof NoClassDefFoundError
                             && INITIALIZATION_ERROR.getMessage() != null
                             && INITIALIZATION_ERROR
                                     .getMessage()
                                     .startsWith("net/bytebuddy/agent/")) {
+                        measurement.branch(4);
                         detail =
                                 join(
                                         "It seems like you are running Mockito with an incomplete or inconsistent class path. Byte Buddy Agent could not be loaded.",
@@ -237,13 +246,16 @@ class InlineDelegateByteBuddyMockMaker
                                     .getMethod("getSystemJavaCompiler")
                                     .invoke(null)
                             == null) {
+                        measurement.branch(5);
                         detail =
                                 "It appears as if you are running on a JRE. Either install a JDK or add JNA to the class path.";
                     } else {
+                        measurement.branch(6);
                         detail =
                                 "It appears as if your JDK does not supply a working agent attachment mechanism.";
                     }
                 } catch (Throwable ignored) {
+                    measurement.branch(7);
                     detail =
                             "It appears as if you are running an incomplete JVM installation that might not support all tooling APIs";
                 }
@@ -255,6 +267,8 @@ class InlineDelegateByteBuddyMockMaker
                             detail,
                             Platform.describe()),
                     INITIALIZATION_ERROR);
+        } else {
+            measurement.branch(0);
         }
 
         ThreadLocal<Class<?>> currentConstruction = new ThreadLocal<>();
@@ -263,34 +277,43 @@ class InlineDelegateByteBuddyMockMaker
         Predicate<Class<?>> isMockConstruction =
                 type -> {
                     if (isSuspended.get()) {
+                        measurement.branch(8);
                         return false;
                     } else if ((currentMocking.get() != null
                                     && type.isAssignableFrom(currentMocking.get()))
                             || currentConstruction.get() != null) {
+                        measurement.branch(9);
                         return true;
                     }
                     Map<Class<?>, ?> interceptors = mockedConstruction.get();
                     if (interceptors != null && interceptors.containsKey(type)) {
+                        measurement.branch(10);
                         // We only initiate a construction mock, if the call originates from an
                         // un-mocked (as suppression is not enabled) subclass constructor.
                         if (isCallFromSubclassConstructor.test(type)) {
+                            measurement.branch(11);
                             return false;
                         }
                         currentConstruction.set(type);
                         return true;
                     } else {
+                        measurement.branch(12);
                         return false;
                     }
                 };
         ConstructionCallback onConstruction =
                 (type, object, arguments, parameterTypeNames) -> {
                     if (currentMocking.get() != null) {
+                        measurement.branch(13);
                         Object spy = currentSpied.get();
                         if (spy == null) {
+                            measurement.branch(14);
                             return null;
                         } else if (type.isInstance(spy)) {
+                            measurement.branch(15);
                             return spy;
                         } else {
+                            measurement.branch(16);
                             isSuspended.set(true);
                             try {
                                 // Unexpected construction of non-spied object
@@ -305,7 +328,10 @@ class InlineDelegateByteBuddyMockMaker
                             }
                         }
                     } else if (currentConstruction.get() != type) {
+                        measurement.branch(17);
                         return null;
+                    } else {
+                        measurement.branch(18);
                     }
                     currentConstruction.remove();
                     isSuspended.set(true);
@@ -313,14 +339,20 @@ class InlineDelegateByteBuddyMockMaker
                         Map<Class<?>, BiConsumer<Object, MockedConstruction.Context>> interceptors =
                                 mockedConstruction.get();
                         if (interceptors != null) {
+                            measurement.branch(18);
                             BiConsumer<Object, MockedConstruction.Context> interceptor =
                                     interceptors.get(type);
                             if (interceptor != null) {
+                                measurement.branch(19);
                                 interceptor.accept(
                                         object,
                                         new InlineConstructionMockContext(
                                                 arguments, object.getClass(), parameterTypeNames));
+                            } else {
+                                measurement.branch(20);
                             }
+                        } else {
+                            measurement.branch(21);
                         }
                     } finally {
                         isSuspended.set(false);

--- a/mockito-core/src/main/java/org/mockito/internal/invocation/SerializableMethod.java
+++ b/mockito-core/src/main/java/org/mockito/internal/invocation/SerializableMethod.java
@@ -9,6 +9,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 
+import org.mockito.CoverageMeasurement;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.creation.SuspendMethod;
 
@@ -99,40 +100,64 @@ public class SerializableMethod implements Serializable, MockitoMethod {
 
     @Override
     public boolean equals(Object obj) {
+        CoverageMeasurement measurement = new CoverageMeasurement("SerializableMethod::equals", 23);
         if (this == obj) {
+            measurement.branch(0);
             return true;
         }
+        measurement.branch(1);
         if (obj == null) {
+            measurement.branch(2);
             return false;
         }
+        measurement.branch(3);
         if (getClass() != obj.getClass()) {
+            measurement.branch(4);
             return false;
         }
+        measurement.branch(5);
         SerializableMethod other = (SerializableMethod) obj;
         if (declaringClass == null) {
+            measurement.branch(6);
             if (other.declaringClass != null) {
+                measurement.branch(7);
                 return false;
             }
+            measurement.branch(8);
         } else if (!declaringClass.equals(other.declaringClass)) {
+            measurement.branch(9);
             return false;
         }
+        measurement.branch(10);
         if (methodName == null) {
+            measurement.branch(11);
             if (other.methodName != null) {
+                measurement.branch(12);
                 return false;
             }
+            measurement.branch(13);
         } else if (!methodName.equals(other.methodName)) {
+            measurement.branch(14);
             return false;
         }
+        measurement.branch(15);
         if (!Arrays.equals(parameterTypes, other.parameterTypes)) {
+            measurement.branch(16);
             return false;
         }
+        measurement.branch(17);
         if (returnType == null) {
+            measurement.branch(18);
             if (other.returnType != null) {
+                measurement.branch(19);
                 return false;
             }
+            measurement.branch(20);
         } else if (!returnType.equals(other.returnType)) {
+            measurement.branch(21);
             return false;
         }
+        measurement.branch(22);
         return true;
     }
 }

--- a/mockito-core/src/main/java/org/mockito/internal/matchers/ArrayEquals.java
+++ b/mockito-core/src/main/java/org/mockito/internal/matchers/ArrayEquals.java
@@ -4,6 +4,7 @@
  */
 package org.mockito.internal.matchers;
 
+import org.mockito.CoverageMeasurement;
 import java.lang.reflect.Array;
 import java.util.Arrays;
 
@@ -15,28 +16,40 @@ public class ArrayEquals extends Equals {
 
     @Override
     public boolean matches(Object actual) {
+        CoverageMeasurement measurement = new CoverageMeasurement("ArrayEquals::matches", 11);
         Object wanted = getWanted();
         if (wanted == null || actual == null) {
+            measurement.branch(0);
             return super.matches(actual);
         } else if (wanted instanceof boolean[] && actual instanceof boolean[]) {
+            measurement.branch(1);
             return Arrays.equals((boolean[]) wanted, (boolean[]) actual);
         } else if (wanted instanceof byte[] && actual instanceof byte[]) {
+            measurement.branch(2);
             return Arrays.equals((byte[]) wanted, (byte[]) actual);
         } else if (wanted instanceof char[] && actual instanceof char[]) {
+            measurement.branch(3);
             return Arrays.equals((char[]) wanted, (char[]) actual);
         } else if (wanted instanceof double[] && actual instanceof double[]) {
+            measurement.branch(4);
             return Arrays.equals((double[]) wanted, (double[]) actual);
         } else if (wanted instanceof float[] && actual instanceof float[]) {
+            measurement.branch(5);
             return Arrays.equals((float[]) wanted, (float[]) actual);
         } else if (wanted instanceof int[] && actual instanceof int[]) {
+            measurement.branch(6);
             return Arrays.equals((int[]) wanted, (int[]) actual);
         } else if (wanted instanceof long[] && actual instanceof long[]) {
+            measurement.branch(7);
             return Arrays.equals((long[]) wanted, (long[]) actual);
         } else if (wanted instanceof short[] && actual instanceof short[]) {
+            measurement.branch(8);
             return Arrays.equals((short[]) wanted, (short[]) actual);
         } else if (wanted instanceof Object[] && actual instanceof Object[]) {
+            measurement.branch(9);
             return Arrays.equals((Object[]) wanted, (Object[]) actual);
         }
+        measurement.branch(10);
         return false;
     }
 

--- a/mockito-core/src/main/java/org/mockito/internal/matchers/apachecommons/EqualsBuilder.java
+++ b/mockito-core/src/main/java/org/mockito/internal/matchers/apachecommons/EqualsBuilder.java
@@ -4,6 +4,7 @@
  */
 package org.mockito.internal.matchers.apachecommons;
 
+import org.mockito.CoverageMeasurement;
 import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockito.plugins.MemberAccessor;
 
@@ -339,47 +340,67 @@ class EqualsBuilder {
      * @return EqualsBuilder - used to chain calls.
      */
     public EqualsBuilder append(Object lhs, Object rhs) {
+        CoverageMeasurement measurement = new CoverageMeasurement("EqualsBuilder::append", 19);
         if (!isEquals) {
+            measurement.branch(0);
             return this;
         }
+        measurement.branch(1);
         if (lhs == rhs) {
+            measurement.branch(2);
             return this;
         }
+        measurement.branch(3);
         if (lhs == null || rhs == null) {
+            measurement.branch(4);
             this.setEquals(false);
             return this;
         }
+        measurement.branch(5);
         Class<?> lhsClass = lhs.getClass();
         if (!lhsClass.isArray()) {
+            measurement.branch(6);
             if (lhs instanceof BigDecimal && rhs instanceof BigDecimal) {
+                measurement.branch(7);
                 isEquals = (((BigDecimal) lhs).compareTo((BigDecimal) rhs) == 0);
             } else {
+                measurement.branch(8);
                 // The simple case, not an array, just test the element
                 isEquals = lhs.equals(rhs);
             }
         } else if (lhs.getClass() != rhs.getClass()) {
+            measurement.branch(9);
             // Here when we compare different dimensions, for example: a boolean[][] to a boolean[]
             this.setEquals(false);
 
             // 'Switch' on type of array, to dispatch to the correct handler
             // This handles multi dimensional arrays of the same depth
         } else if (lhs instanceof long[]) {
+            measurement.branch(10);
             append((long[]) lhs, (long[]) rhs);
         } else if (lhs instanceof int[]) {
+            measurement.branch(11);
             append((int[]) lhs, (int[]) rhs);
         } else if (lhs instanceof short[]) {
+            measurement.branch(12);
             append((short[]) lhs, (short[]) rhs);
         } else if (lhs instanceof char[]) {
+            measurement.branch(13);
             append((char[]) lhs, (char[]) rhs);
         } else if (lhs instanceof byte[]) {
+            measurement.branch(14);
             append((byte[]) lhs, (byte[]) rhs);
         } else if (lhs instanceof double[]) {
+            measurement.branch(15);
             append((double[]) lhs, (double[]) rhs);
         } else if (lhs instanceof float[]) {
+            measurement.branch(16);
             append((float[]) lhs, (float[]) rhs);
         } else if (lhs instanceof boolean[]) {
+            measurement.branch(17);
             append((boolean[]) lhs, (boolean[]) rhs);
         } else {
+            measurement.branch(18);
             // Not an array of primitives
             append((Object[]) lhs, (Object[]) rhs);
         }

--- a/mockito-core/src/main/java/org/mockito/internal/matchers/text/ValuePrinter.java
+++ b/mockito-core/src/main/java/org/mockito/internal/matchers/text/ValuePrinter.java
@@ -4,6 +4,7 @@
  */
 package org.mockito.internal.matchers.text;
 
+import org.mockito.CoverageMeasurement;
 import java.lang.reflect.Array;
 import java.util.Iterator;
 import java.util.Map;
@@ -21,34 +22,54 @@ public class ValuePrinter {
      * Handles explosive toString() implementations.
      */
     public static String print(final Object value) {
+        CoverageMeasurement measurement = new CoverageMeasurement("ValuePrinter::print", 22);
         if (value == null) {
+            measurement.branch(0);
             return "null";
         }
+        measurement.branch(1);
         if (value instanceof String) {
+            measurement.branch(2);
             return '"' + value.toString() + '"';
         }
+        measurement.branch(3);
         if (value instanceof Character) {
+            measurement.branch(4);
             return printChar((Character) value);
         }
+        measurement.branch(5);
         if (value instanceof Long) {
+            measurement.branch(6);
             return value + "L";
         }
+        measurement.branch(7);
         if (value instanceof Double) {
+            measurement.branch(8);
             return value + "d";
         }
+        measurement.branch(9);
         if (value instanceof Float) {
+            measurement.branch(10);
             return value + "f";
         }
+        measurement.branch(11);
         if (value instanceof Short) {
+            measurement.branch(12);
             return "(short) " + value;
         }
+        measurement.branch(13);
         if (value instanceof Byte) {
+            measurement.branch(14);
             return String.format("(byte) 0x%02X", (Byte) value);
         }
+        measurement.branch(15);
         if (value instanceof Map) {
+            measurement.branch(16);
             return printMap((Map<?, ?>) value);
         }
+        measurement.branch(17);
         if (value.getClass().isArray()) {
+            measurement.branch(18);
             return printValues(
                     "[",
                     ", ",
@@ -71,9 +92,12 @@ public class ValuePrinter {
                         }
                     });
         }
+        measurement.branch(19);
         if (value instanceof FormattedText) {
+            measurement.branch(20);
             return (((FormattedText) value).getText());
         }
+        measurement.branch(21);
 
         return descriptionOf(value);
     }


### PR DESCRIPTION
Add CoverageMeasurement class no manually implement branch coverage measurement and added the coverage code for the five functions with highest cyclomatic complexity
- 'InlineDelegateByteBuddyMockMaker::InlineDelegateByteBuddyMockMaker'
- 'ArrayEquals::matches'
- 'EqualsBuilder::append(Object, Object)'
- 'SerializableMethod::equals'
- ValuePrinter::print
