### PR TITLE
Refactor: #9 remove unreachable code in SerializableMethod.equals

### DIFF
--- a/mockito-core/src/main/java/org/mockito/internal/invocation/SerializableMethod.java
+++ b/mockito-core/src/main/java/org/mockito/internal/invocation/SerializableMethod.java
@@ -116,47 +116,18 @@ public class SerializableMethod implements Serializable, MockitoMethod {
 
         // The two SerializableMethod must have equal (possibly both null) declaring classes to be
         // equal
-        if (declaringClass == null) {
-            // Note : unattainable code, a Method cannot have a null declaringClass
-            if (other.declaringClass != null) {
-                return false;
-            }
-        } else if (!declaringClass.equals(other.declaringClass)) {
+        if (!declaringClass.equals(other.declaringClass)) {
             return false;
         }
 
         // The two SerializableMethod must have equal (possibly both null) method names to be equal
-        if (methodName == null) {
-            // Note : unattainable code, a method cannot have a null methodName
-            if (other.methodName != null) {
-                return false;
-            }
-        } else if (!methodName.equals(other.methodName)) {
+        if (!methodName.equals(other.methodName)) {
             return false;
         }
 
         // the two SerializableMethod must have equal element by element parameter types arrays to
         // be equal
         if (!Arrays.equals(parameterTypes, other.parameterTypes)) {
-            return false;
-        }
-
-        // The two SerializableMethod must have equal (possibly both null) return types to be equal
-        if (returnType == null) {
-            // Note : unattainable code, a method cannot have a null returnType
-            if (other.returnType != null) {
-                return false;
-            }
-        } else if (!returnType.equals(other.returnType)) {
-            // Note: unattainable code
-            // methods already have the same name and same parameter types and same declaring class
-            // so they cannot have different return type because having method differ only by their
-            // return type is illegal in java :
-            // class ClassName {
-            //     void method() {}
-            //     int method() {]
-            // }
-            // is illegal.
             return false;
         }
 


### PR DESCRIPTION
Removed the multiple branches in SerializableMethod that are unreachable due to invariants in the built-in reflection `Method` type that is used to construct a SerializableMethod object. More details in the deleted comments of this method.

