### PR TITLE
Feat: #13 improve ArrayEquals coverage

### DIFF
--- a/mockito-core/src/test/java/org/mockito/internal/matchers/ArrayEqualsTest.java
+++ b/mockito-core/src/test/java/org/mockito/internal/matchers/ArrayEqualsTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.matchers;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.mockitoutil.TestBase;
+
+public class ArrayEqualsTest extends TestBase {
+    private ArrayEquals arrayEquals;
+
+    @Test
+    public void test_both_null() {
+        arrayEquals = new ArrayEquals(null);
+        assertTrue(arrayEquals.matches(null));
+    }
+
+    @Test
+    public void test_wanted_null() {
+        arrayEquals = new ArrayEquals(null);
+        assertFalse(arrayEquals.matches(new int[] {4, 4, 4}));
+    }
+
+    @Test
+    public void test_actual_null() {
+        arrayEquals = new ArrayEquals(new int[] {4, 4, 4});
+        assertFalse(arrayEquals.matches(null));
+    }
+    @Test
+    public void test_non_match_arrays() {
+        arrayEquals = new ArrayEquals(new boolean[] {true, false, true});
+        assertFalse(arrayEquals.matches(new int[] {4, 4, 4}));
+    }
+
+    @Test
+    public void test_bool_arrays_match() {
+        arrayEquals = new ArrayEquals(new boolean[] {true, false, true});
+        assertFalse(arrayEquals.matches(new boolean[] {false, false, true}));
+    }
+}

--- a/mockito-core/src/test/java/org/mockito/internal/matchers/text/ValuePrinterTest.java
+++ b/mockito-core/src/test/java/org/mockito/internal/matchers/text/ValuePrinterTest.java
@@ -7,12 +7,23 @@ package org.mockito.internal.matchers.text;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.internal.matchers.text.ValuePrinter.print;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.List;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.Test;
 
 public class ValuePrinterTest {
+
+    @Test
+    public void printValues_test() {
+
+        Iterator<String> iterator = List.of("hello", "cat").iterator();
+        String expect = "(\"hello\",\"cat\")";
+        assertEquals(expect, ValuePrinter.printValues(null, null, null, iterator));
+    }
 
     @Test
     public void prints_values() {

--- a/mockito-core/src/test/java/org/mockito/internal/matchers/text/ValuePrinterTest.java
+++ b/mockito-core/src/test/java/org/mockito/internal/matchers/text/ValuePrinterTest.java
@@ -7,23 +7,12 @@ package org.mockito.internal.matchers.text;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.internal.matchers.text.ValuePrinter.print;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.List;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.Test;
 
 public class ValuePrinterTest {
-
-    @Test
-    public void printValues_test() {
-
-        Iterator<String> iterator = List.of("hello", "cat").iterator();
-        String expect = "(\"hello\",\"cat\")";
-        assertEquals(expect, ValuePrinter.printValues(null, null, null, iterator));
-    }
 
     @Test
     public void prints_values() {


### PR DESCRIPTION
Please do not close #13 yet. This improves coverage of one of the highest CCN methods we found, ArrayEquals.matches(). More can be done and I plan to do so.
